### PR TITLE
Fix issue #9

### DIFF
--- a/esmodules/message-hooks.js
+++ b/esmodules/message-hooks.js
@@ -93,7 +93,7 @@ Hooks.once("ready", () => {
   });
 
   Hooks.on("updateChatMessage", (message) => {
-    addAvatarsToFlags(message);
+    addAvatarsToFlags(message, false);
   });
 
   Hooks.on("renderChatMessage", (app, html, data) => {
@@ -449,7 +449,7 @@ function injectWhisperParticipants(html, messageData) {
   messageHeader.append(whisperParticipants);
 }
 
-function addAvatarsToFlags(message) {
+function addAvatarsToFlags(message, local = true) {
   let combatantImg =
     game.modules.get("combat-tracker-images")?.active && message.actor
       ? message.actor.getFlag("combat-tracker-images", "trackerImage")
@@ -472,12 +472,21 @@ function addAvatarsToFlags(message) {
     tokenAvatar = new TokenAvatar(message.speaker.alias, tokenImg, token.texture.scaleX, actor.size == "sm");
   }
 
-  message.updateSource({
-    "flags.pf2e-dorako-ux.userAvatar": userAvatar,
-    "flags.pf2e-dorako-ux.combatantAvatar": combatantAvatar,
-    "flags.pf2e-dorako-ux.tokenAvatar": tokenAvatar,
-    "flags.pf2e-dorako-ux.actorAvatar": actorAvatar,
-  });
+  if (local) {
+    message.updateSource({
+      "flags.pf2e-dorako-ux.userAvatar": userAvatar,
+      "flags.pf2e-dorako-ux.combatantAvatar": combatantAvatar,
+      "flags.pf2e-dorako-ux.tokenAvatar": tokenAvatar,
+      "flags.pf2e-dorako-ux.actorAvatar": actorAvatar,
+    });
+  } else {
+    message.update({
+      "flags.pf2e-dorako-ux.userAvatar": userAvatar,
+      "flags.pf2e-dorako-ux.combatantAvatar": combatantAvatar,
+      "flags.pf2e-dorako-ux.tokenAvatar": tokenAvatar,
+      "flags.pf2e-dorako-ux.actorAvatar": actorAvatar,
+    });
+  }
 }
 
 function getAvatar(message) {


### PR DESCRIPTION
Makes the `updateChatMessage` hook use `update` instead of `updateSource`, so that it gets updated on the backend.