### PR TITLE
Fix for updates with multiple users

### DIFF
--- a/esmodules/message-hooks.js
+++ b/esmodules/message-hooks.js
@@ -479,7 +479,7 @@ function addAvatarsToFlags(message, local = true) {
       "flags.pf2e-dorako-ux.tokenAvatar": tokenAvatar,
       "flags.pf2e-dorako-ux.actorAvatar": actorAvatar,
     });
-  } else {
+  } else if (game.user.id == message.user.id) {
     message.update({
       "flags.pf2e-dorako-ux.userAvatar": userAvatar,
       "flags.pf2e-dorako-ux.combatantAvatar": combatantAvatar,


### PR DESCRIPTION
I know you just made a release, but I found a bug in the change I made that only happens when multiple users are present, so I didn't catch it. Sincerest apologies, I should've done more testing before committing.

This fix makes it such that only the owner of the message will update the dorako-ux flags on it. Without this, every user except the one who made the message will see a "[user] does not have permission to update ChatMessage" error banner if a message is updated.
