### PR TITLE
Add token effect hud clipping setting, general performance improvements

### DIFF
--- a/esmodules/dorako-ux/radial-condition-hud.js
+++ b/esmodules/dorako-ux/radial-condition-hud.js
@@ -70,7 +70,7 @@ function updateEffectScales(token) {
 
       const iconScale = sizeToIconScale(tokenSize);
       const gridScale = gridSize / 100;
-      const scaledSize = 13 * iconScale * gridScale;
+      const scaledSize = 14 * iconScale * gridScale;
       updateIconSize(effectIcon, scaledSize);
       updateIconPosition(effectIcon, i, effectIcons, token);
     });

--- a/esmodules/dorako-ux/radial-condition-hud.js
+++ b/esmodules/dorako-ux/radial-condition-hud.js
@@ -1,5 +1,3 @@
-let circularMaskTexture = null;
-
 function countEffects(token) {
   if (!token) {
     return 0;
@@ -51,6 +49,34 @@ function updateIconPosition(effectIcon, i, effectIcons, token) {
   effectIcon.position.y = (-1 * y) / 2 + (gridSize * tokenTileFactor) / 2;
 }
 
+function updateEffectScales(token) {
+  const numEffects = countEffects(token);
+  if (numEffects > 0 && token.effects.children.length > 0) {
+    const background = token.effects.children[0];
+    if (!(background instanceof PIXI.Graphics)) return;
+    // background.clear()
+    background.visible = false; // don't need background layer as we can cache it in the texture itself
+
+    // Exclude the background and overlay
+    const effectIcons = token.effects.children.slice(1, 1 + numEffects);
+    const tokenSize = token?.actor?.size;
+
+    const gridSize = token?.scene?.grid?.size ?? 100;
+    // Reposition and scale them
+    effectIcons.forEach((effectIcon, i, effectIcons) => {
+      if (!(effectIcon instanceof PIXI.Sprite)) return;
+
+      effectIcon.anchor.set(0.5);
+
+      const iconScale = sizeToIconScale(tokenSize);
+      const gridScale = gridSize / 100;
+      const scaledSize = 13 * iconScale * gridScale;
+      updateIconSize(effectIcon, scaledSize);
+      updateIconPosition(effectIcon, i, effectIcons, token);
+    });
+  }
+}
+
 // Nudge icons to be on the token ring or slightly outside
 function sizeToOffset(size) {
   if (size == "tiny") {
@@ -86,94 +112,144 @@ function sizeToIconScale(size) {
   return 1.0;
 }
 
-function drawBG(effectIcon, background, gridScale) {
-  const r = effectIcon.width / 2;
+function createBG(iconSize, borderWidth) {
+  const background = new PIXI.Graphics();
+  const r = iconSize / 2;
   const isDorakoUiActive = game.modules.get("pf2e-dorako-ui")?.active;
   const appTheme = isDorakoUiActive ? game.settings.get("pf2e-dorako-ui", "theme.app-theme") : false;
   if (appTheme && appTheme.includes("foundry2")) {
-    background.lineStyle((1 * gridScale) / 2, 0x302831, 1, 0);
-    background.drawCircle(effectIcon.position.x, effectIcon.position.y, r + 1 * gridScale);
+    background.lineStyle(borderWidth, 0x302831, 1, 0);
     background.beginFill(0x0b0a13);
-    background.drawCircle(effectIcon.position.x, effectIcon.position.y, r + 1 * gridScale);
+    background.drawCircle(r, r, r);
     background.endFill();
-    return;
   } else if (appTheme && appTheme.includes("crb")) {
-    background.lineStyle((1 * gridScale) / 2, 0x956d58, 1, 1);
-    background.drawCircle(effectIcon.position.x, effectIcon.position.y, r + 1 * gridScale);
-    background.lineStyle((1 * gridScale) / 2, 0xe9d7a1, 1, 0);
-    background.drawCircle(effectIcon.position.x, effectIcon.position.y, r + 1 * gridScale);
+    background.lineStyle(borderWidth, 0x956d58, 1, 0);
+    background.drawCircle(r, r, r);
+    background.lineStyle(borderWidth, 0xe9d7a1, 1, 0);
     background.beginFill(0x956d58);
-    background.drawCircle(effectIcon.position.x, effectIcon.position.y, r + 1 * gridScale);
+    background.drawCircle(r, r, r - borderWidth);
     background.endFill();
-    return;
   } else if (appTheme && appTheme.includes("bg3")) {
-    background.lineStyle((1 * gridScale) / 2, 0x9a8860, 1, 1);
-    background.drawCircle(effectIcon.position.x, effectIcon.position.y, r + 1 * gridScale);
-    background.lineStyle((1 * gridScale) / 2, 0xd3b87c, 1, 0);
-    background.drawCircle(effectIcon.position.x, effectIcon.position.y, r + 1 * gridScale);
+    background.lineStyle(borderWidth, 0x9a8860, 1, 0);
+    background.drawCircle(r, r, r);
+    background.lineStyle(borderWidth, 0xd3b87c, 1, 0);
     background.beginFill(0x000000);
-    background.drawCircle(effectIcon.position.x, effectIcon.position.y, r + 1 * gridScale);
+    background.drawCircle(r, r, r - borderWidth);
     background.endFill();
-    return;
+  } else {
+    background.lineStyle(borderWidth, 0x444444, 1, 0);
+    background.beginFill(0x222222);
+    background.drawCircle(r, r, r);
+    background.endFill();
   }
-  // background.lineStyle((1 * gridScale) / 2, 0x222222, 1, 1);
-  // background.drawCircle(effectIcon.position.x, effectIcon.position.y, r + 1 * gridScale);
-  background.lineStyle((1 * gridScale) / 2, 0x444444, 1, 0);
-  background.drawCircle(effectIcon.position.x, effectIcon.position.y, r + 1 * gridScale);
-  background.beginFill(0x222222);
-  background.drawCircle(effectIcon.position.x, effectIcon.position.y, r + 1 * gridScale);
-  background.endFill();
+  return background;
 }
 
-function updateEffectScales(token) {
-  // if (token?.actor?.size == "sm") return;
-  const numEffects = countEffects(token);
-  if (numEffects > 0 && token.effects.children.length > 0) {
-    const background = token.effects.children[0];
-    if (!(background instanceof PIXI.Graphics)) return;
+class EffectTextureSpritesheet {
+  static #spriteSize = 128;
+  static #baseTextureSize = 2048;
+  static #maxMemberCount = Math.pow(this.#baseTextureSize / this.#spriteSize, 2);
 
-    background.clear();
+  static get spriteSize() {
+    return this.#spriteSize;
+  }
+  static get baseTextureSize() {
+    return this.#baseTextureSize;
+  }
 
-    // Exclude the background and overlay
-    const effectIcons = token.effects.children.slice(1, 1 + numEffects);
-    const tokenSize = token?.actor?.size;
+  static get maxMemberCount() {
+    return this.#maxMemberCount;
+  }
 
-    const gridSize = token?.scene?.grid?.size ?? 100;
-    // Reposition and scale them
-    effectIcons.forEach((effectIcon, i, effectIcons) => {
-      if (!(effectIcon instanceof PIXI.Sprite)) return;
+  #baseTextures = [];
+  #textureCache = new Map();
 
-      effectIcon.anchor.set(0.5);
-
-      const iconScale = sizeToIconScale(tokenSize);
-      const gridScale = gridSize / 100;
-      const scaledSize = 12 * iconScale * gridScale;
-      updateIconSize(effectIcon, scaledSize);
-      updateIconPosition(effectIcon, i, effectIcons, token);
-      drawBG(effectIcon, background, gridScale);
+  #createBaseRenderTexture() {
+    const baseTextureSize = this.constructor.baseTextureSize;
+    return new PIXI.BaseRenderTexture({
+      width: baseTextureSize,
+      height: baseTextureSize,
     });
   }
-}
 
-Hooks.once("ready", () => {
+  #getNextBaseRenderTexture() {
+    const lastIdx = this.#baseTextures.length - 1;
+    const currentTexture = this.#baseTextures[lastIdx];
+    if (!currentTexture || currentTexture[1] >= this.constructor.maxMemberCount) {
+      const baseRenderTexture = this.#createBaseRenderTexture();
+      this.#baseTextures.push([baseRenderTexture, 1]);
+      return [baseRenderTexture, 0];
+    }
+    this.#baseTextures[lastIdx][1] = currentTexture[1] + 1;
+    return currentTexture;
+  }
+
+  addToEffectTexture(path, renderable) {
+    const existingTexture = this.#textureCache.get(path);
+    console.log("adding!", path);
+    if (existingTexture) {
+      return existingTexture;
+    }
+    // load base render texture or create new if it does not exist
+    const [baseRenderTexture, textureCount] = this.#getNextBaseRenderTexture();
+
+    const spriteSize = this.constructor.spriteSize;
+    const maxCols = this.constructor.baseTextureSize / spriteSize;
+    const col = textureCount % maxCols;
+    const row = Math.floor(textureCount / maxCols);
+    const frame = new PIXI.Rectangle(col * spriteSize, row * spriteSize, spriteSize, spriteSize);
+    console.log(frame);
+    const renderTexture = new PIXI.RenderTexture(baseRenderTexture, frame);
+    canvas.app.renderer.render(renderable, { renderTexture: renderTexture });
+    this.#textureCache.set(path, renderTexture);
+    return renderTexture;
+  }
+
+  getEffectTexture(path) {
+    return this.#textureCache.get(path);
+  }
+}
+const effectCache = new EffectTextureSpritesheet();
+
+const createRoundedEffectIcon = (effectIcon) => {
+  const texture = effectIcon.texture;
+  const borderWidth = 4;
+  const textureSize = EffectTextureSpritesheet.spriteSize;
+
+  const container = new PIXI.Container();
+  container.width = textureSize;
+  container.height = textureSize;
+
+  container.addChild(createBG(textureSize, borderWidth));
+  container.addChild(effectIcon);
+
+  const effectSize = textureSize - 6 * borderWidth;
+  let scale = effectSize / Math.max(texture.height, texture.width);
+  effectIcon.scale.set(scale, scale);
+  effectIcon.x = (textureSize - effectIcon.width) / 2;
+  effectIcon.y = (textureSize - effectIcon.height) / 2;
+  const clipRadius = textureSize / 2 - 3 * borderWidth;
+  effectIcon.mask = new PIXI.Graphics()
+    .beginFill(0xffffff)
+    .drawCircle(textureSize / 2, textureSize / 2, clipRadius)
+    .endFill();
+  return container;
+};
+
+function overrideTokenHud() {
   const enabled = game.settings.get("pf2e-dorako-ux", "moving.adjust-token-effects-hud");
-  if (!enabled) return;
+  if (!enabled) {
+    return;
+  }
 
   const origRefreshEffects = Token.prototype._refreshEffects;
   Token.prototype._refreshEffects = function (...args) {
-    // const enabled = game.settings.get("pf2e-dorako-ux", "ux.adjust-token-effects-hud");
-    // if (!enabled) {
-    //   origRefreshEffects.apply(this, args);
-    //   return;
-    // }
     if (this) {
       origRefreshEffects.apply(this, args);
       updateEffectScales(this);
     }
   };
 
-  const origDrawEffect = Token.prototype._drawEffect;
-  const effectTextureCache = new Map();
   Token.prototype._drawEffect = async function (...args) {
     if (!this) {
       return;
@@ -181,39 +257,42 @@ Hooks.once("ready", () => {
     const src = args[0];
     if (!src) return;
 
-    let fallbackEffectIcon = "icons/svg/hazard.svg";
+    const fallbackEffectIcon = "icons/svg/hazard.svg";
     const effectTextureCacheKey = src || fallbackEffectIcon;
-    let effectTexture = effectTextureCache.get(effectTextureCacheKey);
+    let effectTexture = effectCache.getEffectTexture(effectTextureCacheKey);
     let icon;
     if (effectTexture) {
       icon = new PIXI.Sprite(effectTexture);
     } else {
-      let tex = await loadTexture(src, { fallback: fallbackEffectIcon });
-      icon = new PIXI.Sprite(tex);
+      const texture = await loadTexture(src, { fallback: fallbackEffectIcon });
+      const rawEffectIcon = new PIXI.Sprite(texture);
 
       if (game.system.id === "pf2e" && src == game.settings.get("pf2e", "deathIcon")) {
-        return this.effects.addChild(icon);
+        return this.effects.addChild(rawEffectIcon);
       }
-      const minDimension = Math.min(icon.width, icon.height);
-
-      // Use the blurred pre-made texture and create a new mask sprite for the specific icon
-      const myMask = new PIXI.Graphics().beginFill(0xffffff).drawCircle(55, 55, 55).endFill();
-      myMask.width = minDimension;
-      myMask.height = minDimension;
-      // myMask.x = -icon.width / 2
-      // myMask.y = -icon.height / 2
-
-      icon.mask = myMask;
-      icon.addChild(myMask);
-      effectTexture = PIXI.RenderTexture.create({
-        width: minDimension,
-        height: minDimension,
-      });
-      canvas.app.renderer.render(icon, { renderTexture: effectTexture });
-      effectTextureCache.set(effectTextureCacheKey, effectTexture);
+      effectTexture = effectCache.addToEffectTexture(effectTextureCacheKey, createRoundedEffectIcon(rawEffectIcon));
       icon = new PIXI.Sprite(effectTexture);
     }
 
+    console.log(icon.width, icon.height);
     return this.effects.addChild(icon);
   };
+}
+function overrideInterfaceClipping() {
+  const enabled = game.settings.get("pf2e-dorako-ux", "moving.adjust-token-effects-hud-clipping");
+  if (!enabled) {
+    return;
+  }
+
+  const origRefreshState = Token.prototype._refreshState;
+  Token.prototype._refreshState = function (...args) {
+    origRefreshState.apply(this, args);
+    this.removeChild(this.voidMesh);
+    // this.addChildAt(this.voidMesh, this.getChildIndex(this.effects) + 1);
+  };
+}
+
+Hooks.once("ready", () => {
+  overrideTokenHud();
+  overrideInterfaceClipping();
 });

--- a/esmodules/settings/moving-settings.js
+++ b/esmodules/settings/moving-settings.js
@@ -11,6 +11,7 @@ export class MovingSettings extends SettingsMenuDorakoUX {
     // "minimize-hotbar", // Broken
     "center-hotbar",
     "adjust-token-effects-hud",
+    "adjust-token-effects-hud-clipping",
     "animate-messages",
     "controls-alignment",
   ];
@@ -89,6 +90,15 @@ export class MovingSettings extends SettingsMenuDorakoUX {
         scope: "client",
         type: Boolean,
         default: true,
+        config: true,
+        requiresReload: true,
+      },
+      "adjust-token-effects-hud-clipping": {
+        name: "pf2e-dorako-ux.settings.adjust-token-effects-hud-clipping.name",
+        hint: "pf2e-dorako-ux.settings.adjust-token-effects-hud-clipping.hint",
+        scope: "client",
+        type: Boolean,
+        default: false,
         config: true,
         requiresReload: true,
       },

--- a/languages/de.json
+++ b/languages/de.json
@@ -8,6 +8,10 @@
         "hint": "Stelle Effekte kreisförmig da und arrangiere sie außerhalb oder auf dem Token-Ring bei größeren Tokens",
         "name": "\"Token Effects HUD\" anpassen?"
       },
+      "adjust-token-effects-hud-clipping": {
+        "hint": "Verhindert, dass effekt-icons von anderen Tokens überdeckt werden. Bringt starke Performance-Gewinne mit sich.",
+        "name": "Token Effecte über alle Tokens anzeigen?"
+      },
       "animate-messages": {
         "hint": "Flüstern von Spielern zum SL erregt mehr Aufmerksamkeit",
         "name": "Animierte Nachrichten, um die Aufmerksamkeit auf bestimmte Ereignisse zu lenken?"

--- a/languages/en.json
+++ b/languages/en.json
@@ -77,6 +77,10 @@
         "hint": "Makes effects circular and arranges them outside the token, or on the token ring for larger tokens",
         "name": "Adjust token effects HUD?"
       },
+      "adjust-token-effects-hud-clipping": {
+        "hint": "Makes effects always display above other tokens. Also drastically increases performance.",
+        "name": "Adjust token effect render order?"
+      },
       "animate-messages": {
         "hint": "Makes whispers from players to GM draw more attention",
         "name": "Animate messages to draw attention to certain events?"


### PR DESCRIPTION
This PR contains several performance improvements to the way the radial HUD is rendered.

### Fold background layer with cached effect icons
We already cache the radial effect icons because of expensive mask operations. Becuase we use PIXI.Graphics for creating the background layer (the outlines and backgrounds for the radial token effect icons), rendering the layer introduces one additional draw call per token that has status effects. This PR simply stores this circular background in the same cached texture as the token icon itself, eliminating the need to render the background layer at all.
This alone increases the performance by about 80% in my case for a 35 token, > 500 status effects test scene and decreases the draw calls from about 190 to 160.

### Render multiple effect icons to the same base texture
Currently, each status effect icon uses its own texture when creating the cached, circular status effect icon. Instead of creating one texture for each icon, we can create one (or very few) base textures sized 2048x2048px and render the effect icons as 128x128px chunks to this texture. The cached status effect icon texture is then just a view to this larger texture, making draw operations much faster as no texture switch is necessary anymore when rendering status effects.

This configuration allows for 256 status effect icons to be cached in one texture. This should be enough for almost all cases, but in case one texture is not enough, more are created on the fly as they are needed.

The performance increase of this in isolation is only a few percent (and further decreaes the draw calls to about 130 in my case), but it allows for more efficient batching, especially with the last, optional performance hack.

### Optional: Remove clipping of interface icons with token images.
This is a new, optional (disabled by default) client setting, that simply disabled the voidLayer that clips the interface elements to token images. This allows for all token effects for all tokens to be rendered in one (or very few) batches.
Together with the texture atlas optimization, this reduces draw calls to just 24 and increases performance by about another 100%.

On my machine before optimazations: 22fps. With just the optimizations to rendering the status effect icons: 40fps. Without clipping of the interface layer: about 80fps.